### PR TITLE
added copy templates function at first execution.

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -14,8 +14,8 @@ OUTPUT_PATH="./outputs"
 SKETCH_TOOL_PATH="/Applications/Sketch.app/Contents/Resources/sketchtool/bin/sketchtool"
 
 #### Figma related ####
-# file id of target figma file, refer link below
-# https://www.figma.com/developers/docs#authentication
+# file id of target figma file, you can get it from figma url like below:
+# https://www.figma.com/file/{{FILE_KEY}}/sample_for_test
 FIGMA_FILE_KEY="FILE_KEY_HERE"
 
 # access token for the file above, refer link below

--- a/core/iosPlatform/applications/AssetGenerator.ts
+++ b/core/iosPlatform/applications/AssetGenerator.ts
@@ -27,16 +27,14 @@ export class AssetGenerator {
   constructor(outputDir?: string) {
     this.pathManager = new PathManager(outputDir);
     this.templateHelpers = new HandlebarsHelpers(this.pathManager);
-    const templatePath = path.isAbsolute(process.env.TEMPLATE_DIR)
-      ? process.env.TEMPLATE_DIR
-      : path.resolve(process.cwd(), process.env.TEMPLATE_DIR);
-    this.projectTemplateRootDir = path.join(
-      templatePath,
+
+    const projTmplRootDir = this.templateHelpers.templatePathFor(
       OSType.ios,
       'XcodeProjectTemplate',
     );
-    const partialTemplateRootDir = path.join(
-      templatePath,
+    this.projectTemplateRootDir = projTmplRootDir;
+
+    const partialTemplateRootDir = this.templateHelpers.templatePathFor(
       OSType.ios,
       'partials',
     );


### PR DESCRIPTION
 - if `TEMPLATE_DIR` exits, just use that directory (will raise an error if its contents is empty)
 - if `TEMPLATE_DIR` does not exist, just copy original template to that directory